### PR TITLE
Refactor/authenticated api

### DIFF
--- a/flaskr/__init__.py
+++ b/flaskr/__init__.py
@@ -1,7 +1,11 @@
-from flask import Flask
+import json
+
+from flask import Flask, Response
 from flask_restful import Api, Resource
 
 from thirdparty.hahow import get_hero_by_id, get_heros
+
+from .error_handler import err_response
 
 app = Flask(__name__)
 api = Api(app)
@@ -14,12 +18,24 @@ def test():
 
 class HeroList(Resource):
     def get(self):
-        return get_heros()
+        resp = get_heros()
+        if resp["status"] != "Success":
+            return err_response(resp["error_code"])
+
+        return Response(
+            json.dumps(resp["data"]), status=200, mimetype="application/json"
+        )
 
 
 class Hero(Resource):
     def get(self, hero_id):
-        return get_hero_by_id(hero_id)
+        resp = get_hero_by_id(hero_id)
+        if resp["status"] != "Success":
+            return err_response(resp["error_code"])
+
+        return Response(
+            json.dumps(resp["data"]), status=200, mimetype="application/json"
+        )
 
 
 api.add_resource(HeroList, "/heroes")

--- a/flaskr/error_handler.py
+++ b/flaskr/error_handler.py
@@ -2,7 +2,11 @@ from flask import Response
 
 
 def err_response(status_code: int) -> Response:
-    if status_code == 404:
+    if status_code == 400:
+        return Response("Bad Request", status=400)
+    elif status_code == 401:
+        return Response("Unauthorized client", status=401)
+    elif status_code == 404:
         return Response("Not found", status=404)
     else:
         return Response("Internal Server Error", status=500)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -55,7 +55,7 @@ def test_get_hero_by_id_success(client, mocker):
 
 
 def test_get_hero_by_id_404(client, mocker):
-    mocker.patch("flaskr.get_heros", return_value={"status": "Fail", "error_code": 404})
+    mocker.patch("flaskr.get_hero_by_id", return_value={"status": "Fail", "error_code": 404})
 
     response = client.get("/heroes/5")
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,9 +1,6 @@
 import pytest
 from flask import json
-
 from flaskr import app
-
-from .utils import MockResponse
 
 
 @pytest.fixture
@@ -38,9 +35,7 @@ data = [
 
 
 def test_get_heros_success(client, mocker):
-    mocker.patch(
-        "api.hahow.requests.get", return_value=MockResponse(data=data, status_code=200)
-    )
+    mocker.patch("flaskr.get_heros", return_value={"status": "Success", "data": data})
 
     response = client.get("/heroes")
 
@@ -48,10 +43,9 @@ def test_get_heros_success(client, mocker):
     assert json.loads(response.data) == data
 
 
-def test_get_hero_by_id(client, mocker):
+def test_get_hero_by_id_success(client, mocker):
     mocker.patch(
-        "api.hahow.requests.get",
-        return_value=MockResponse(status_code=200, data=data[0]),
+        "flaskr.get_hero_by_id", return_value={"status": "Success", "data": data[0]}
     )
 
     response = client.get("/heroes/1")
@@ -60,10 +54,8 @@ def test_get_hero_by_id(client, mocker):
     assert json.loads(response.data)["id"] == "1"
 
 
-def test_get_hero_by_id_not_found(client, mocker):
-    mocker.patch(
-        "api.hahow.requests.get", return_value=MockResponse(status_code=404, data={})
-    )
+def test_get_hero_by_id_404(client, mocker):
+    mocker.patch("flaskr.get_heros", return_value={"status": "Fail", "error_code": 404})
 
     response = client.get("/heroes/5")
 

--- a/thirdparty/hahow.py
+++ b/thirdparty/hahow.py
@@ -1,10 +1,4 @@
-import json
-from json.decoder import JSONDecodeError
-
 import requests
-from flask import Response
-
-from .error_handler import err_response
 
 
 def get_heros():
@@ -12,14 +6,9 @@ def get_heros():
     resp = requests.get(endpoint)
 
     if resp.status_code != 200:
-        return err_response(resp.status_code)
+        return {"status": "Fail", "error_code": resp.status_code}
 
-    try:
-        data = resp.json()
-    except JSONDecodeError:
-        return Response("The Returned data is not json decodable", status=500)
-
-    return Response(json.dumps(data), status=200, mimetype="application/json")
+    return {"status": "Success", "data": resp.json()}
 
 
 def get_hero_by_id(hero_id):
@@ -27,11 +16,21 @@ def get_hero_by_id(hero_id):
     resp = requests.get(endpoint)
 
     if resp.status_code != 200:
-        return err_response(resp.status_code)
+        return {"status": "Fail", "error_code": resp.status_code}
 
-    try:
-        data = resp.json()
-    except JSONDecodeError:
-        return Response("The Returned data is not json decodable", status=500)
+    return {"status": "Success", "data": resp.json()}
 
-    return Response(json.dumps(data), status=200, mimetype="application/json")
+
+def get_profile_by_id(hero_id):
+    endpoint = f"https://hahow-recruit.herokuapp.com/heroes/{hero_id}/profile"
+    resp = requests.get(endpoint)
+    return resp.json()
+
+
+def auth(username, password):
+    endpoint = "https://hahow-recruit.herokuapp.com/auth"
+    resp = requests.post(endpoint, json={"name": username, "password": password})
+
+    if resp.status_code != 200:
+        return False
+    return True


### PR DESCRIPTION
The third-party api should return data instead of Response object, because there may be future need to concat data from multiple third-party api. (EX. after authenctication, the /heroes endpoint will return extra profile data